### PR TITLE
⚡ Add `date` in `historical_data` response

### DIFF
--- a/src/investiny/historical.py
+++ b/src/investiny/historical.py
@@ -44,6 +44,7 @@ def historical_data(
     }
     data = request_to_investing(endpoint="history", params=params)
     return {
+        "date": [datetime.fromtimestamp(t).strftime("%m/%d/%Y") for t in data["t"]],  # type: ignore
         "open": data["o"],  # type: ignore
         "high": data["h"],  # type: ignore
         "low": data["l"],  # type: ignore

--- a/tests/test_historical.py
+++ b/tests/test_historical.py
@@ -11,12 +11,12 @@ def test_historical(investing_id: int, from_date: str, to_date: str) -> None:
     res = historical_data(
         investing_id=investing_id, from_date=from_date, to_date=to_date
     )
-    assert all(key in res.keys() for key in ["open", "high", "low", "close"])
+    assert all(key in res.keys() for key in ["date", "open", "high", "low", "close"])
     assert isinstance(res, dict)
 
 
 @pytest.mark.usefixtures("investing_id")
 def test_historical_without_dates(investing_id: int) -> None:
     res = historical_data(investing_id=investing_id)
-    assert all(key in res.keys() for key in ["open", "high", "low", "close"])
+    assert all(key in res.keys() for key in ["date", "open", "high", "low", "close"])
     assert isinstance(res, dict)


### PR DESCRIPTION
## ✨ Features

- Add `date` key-value pair in `historical_data`'s output

## 🔗 Linked Issue

#8 

## 🧪 Tests

- [X] Did you implement unit tests if required?

If the above checkbox is checked, describe how you unit tested it.

Add value in the list for the assertion to pass, so that when `historical_data`'s output keys are checked, `date` is checked too, otherwise the unit tests will fail.