### PR TITLE
✨ Add `volume` to `historical_data`'s output if exists

### DIFF
--- a/src/investiny/historical.py
+++ b/src/investiny/historical.py
@@ -44,10 +44,13 @@ def historical_data(
     }
     data = request_to_investing(endpoint="history", params=params)
     time_format = "%H:%M %m/%d/%Y" if isinstance(interval, int) else "%m/%d/%Y"
-    return {
+    output = {
         "date": [datetime.fromtimestamp(t).strftime(time_format) for t in data["t"]],  # type: ignore
         "open": data["o"],  # type: ignore
         "high": data["h"],  # type: ignore
         "low": data["l"],  # type: ignore
         "close": data["c"],  # type: ignore
     }
+    if "v" in data:
+        output["volume"] = data["v"]  # type: ignore
+    return output

--- a/tests/test_historical.py
+++ b/tests/test_historical.py
@@ -11,12 +11,16 @@ def test_historical(investing_id: int, from_date: str, to_date: str) -> None:
     res = historical_data(
         investing_id=investing_id, from_date=from_date, to_date=to_date
     )
-    assert all(key in res.keys() for key in ["date", "open", "high", "low", "close"])
+    assert all(
+        key in res.keys() for key in ["date", "open", "high", "low", "close", "volume"]
+    )
     assert isinstance(res, dict)
 
 
 @pytest.mark.usefixtures("investing_id")
 def test_historical_without_dates(investing_id: int) -> None:
     res = historical_data(investing_id=investing_id)
-    assert all(key in res.keys() for key in ["date", "open", "high", "low", "close"])
+    assert all(
+        key in res.keys() for key in ["date", "open", "high", "low", "close", "volume"]
+    )
     assert isinstance(res, dict)


### PR DESCRIPTION
## ✨ Features

- Add `volume` to `historical_data`'s output if `volume` exists
- Add missing assertion for `volume` column in `historica_data`'s output

## 🔗 Linked Issue

#17 

## 🧪 Tests

- [X] Did you implement unit tests if required?

If the above checkbox is checked, describe how you unit-tested it.

Add missing value (`volume`) in list with column names for assertion over `historical_data`'s output to pass.