### PR TITLE
✨ Support Python 3.8+ and extend docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.8-slim
 
 RUN apt-get update \
     && apt-get install build-essential git -y --no-install-recommends

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ which seems to be more reliable right now according to the ran tests, as well as
 
 ## 🛠️ Installation
 
-🤏🏻 `investiny` requires Python 3.9+ and can be installed with `pip` as it follows:
+🤏🏻 `investiny` requires Python 3.8+ and can be installed with `pip` as it follows:
 
 `pip install investiny`
 

--- a/docs/api/historical.md
+++ b/docs/api/historical.md
@@ -1,0 +1,1 @@
+::: investiny.historical.historical_data

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -1,0 +1,1 @@
+::: investiny.search.search_assets

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,31 @@
+# 🤝🏻 Integrations
+
+Here we'll explain how to integrate `investiny` with other packages/libraries.
+
+## 🐼 Pandas
+
+You'll need to install `pandas` as `pip install pandas`, and then in case you want to mimic
+`investpy`'s output for historical data retrieval functions, you'll need to run the following
+code:
+
+```python
+from investiny import historical_data
+import pandas as pd
+
+output = historical_data(investing_id=6408)
+data = pd.DataFrame.from_dict(output)
+data.rename(columns={
+    "date": "Date",
+    "open": "Open",
+    "high": "High",
+    "low": "Low",
+    "close": "Close",
+    "volume": "Volume"
+}, inplace=True)
+data.set_index("Date", inplace=True)
+```
+
+## ➕ More to come...
+
+Feel free to submit a PR to update the documenation by adding more integrations with any
+other package/library that you think can be useful to be documented.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,3 +1,3 @@
 # 📃 Requirements
 
-Python 3.9+
+Python 3.8+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,5 +52,8 @@ nav:
   - Requirements: requirements.md
   - Installation: installation.md
   - Usage: usage.md
+  - API Reference:
+      - Historical: api/historical.md
+      - Search: api/search.md
   - Disclaimer: disclaimer.md
   - License: license.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,12 @@ markdown_extensions:
       anchor_linenums: true
   - pymdownx.superfences
 
+plugins:
+  - search:
+  - git-revision-date-localized:
+      type: timeago
+      enable_creation_date: true
+
 extra:
   social:
     - icon: fontawesome/brands/python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,5 +51,5 @@ nav:
   - Requirements: requirements.md
   - Installation: installation.md
   - Usage: usage.md
-  - License: license.md
   - Disclaimer: disclaimer.md
+  - License: license.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,20 @@ repo_url: https://github.com/alvarobartt/investiny
 
 copyright: Copyright &copy; 2022 Alvaro Bartolome
 
-theme: material
+theme:
+  name: material
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  font:
+    text: Roboto
+    code: Roboto Mono
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ plugins:
   - git-revision-date-localized:
       type: timeago
       enable_creation_date: true
+  - mkdocstrings:
 
 extra:
   social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
   - Requirements: requirements.md
   - Installation: installation.md
   - Usage: usage.md
+  - Integrations: integrations.md
   - API Reference:
       - Historical: api/historical.md
       - Search: api/search.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,10 @@ httpx = "^0.23.0"
 mkdocs = { version = "^1.4.0", optional = true }
 mkdocs-material = { version = "^8.5.4", optional = true }
 mkdocs-git-revision-date-localized-plugin = { version = "^1.1.0", optional = true }
+mkdocstrings = { version = "^0.19.0", extras = ["python"], optional = true }
 
 [tool.poetry.extras]
-docs = ["mkdocs", "mkdocs-material", "mkdocs-git-revision-date-localized-plugin"]
+docs = ["mkdocs", "mkdocs-material", "mkdocs-git-revision-date-localized-plugin", "mkdocstrings"]
 
 [tool.poetry.dev-dependencies]
 black = "^22.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,10 @@ python = "^3.8"
 httpx = "^0.23.0"
 mkdocs = { version = "^1.4.0", optional = true }
 mkdocs-material = { version = "^8.5.4", optional = true }
+mkdocs-git-revision-date-localized-plugin = { version = "^1.1.0", optional = true }
 
 [tool.poetry.extras]
-docs = ["mkdocs", "mkdocs-material"]
+docs = ["mkdocs", "mkdocs-material", "mkdocs-git-revision-date-localized-plugin"]
 
 [tool.poetry.dev-dependencies]
 black = "^22.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ repository = "https://investiny.readthedocs.io/"
 license = "MIT License"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.8"
 httpx = "^0.23.0"
 mkdocs = { version = "^1.4.0", optional = true }
 mkdocs-material = { version = "^8.5.4", optional = true }

--- a/src/investiny/search.py
+++ b/src/investiny/search.py
@@ -25,6 +25,17 @@ def search_assets(
     ] = None,
     exchange: Union[str, None] = None,
 ) -> List[Dict[str, Any]]:
+    """Search any available asset at Investing.com.
+
+    Args:
+        query (str): Query to search for.
+        limit (int, optional): Maximum number of results to retrieve. Defaults to 10.
+        type (Union[Literal["Stock", "ETF", "Commodity", "Index", "Future", "Yield", "FX"], None], optional): Type of asset to search for. Defaults to None.
+        exchange (Union[str, None], optional): Exchange to search for. Defaults to None.
+
+    Returns:
+        List[Dict[str, Any]]: A list of dictionaries with the search results.
+    """
     params = {
         "query": query,
         "limit": limit,


### PR DESCRIPTION
## ✨ Features

- Downgrade minimum supported Python version from 3.9+ to 3.8+
- Use `python:3.8-slim` instead of `python:3.9-slim` to test Python 3.8+ support
- Add API Reference in documentation from `mkdocstrings`
- Include creation and last-update dates in documentation from `mkdocs-git-revision-date-localized-plugin`
- Add `integrations.md` to explain how to export `investiny`'s output to `pandas`
- Add missing `search_assets` docstrings

## 🔗 Linked Issue

#18 