### PR TITLE
🥅 Handle data limits from each Investing.com request

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,8 +10,6 @@
 		"ms-azuretools.vscode-docker",
 		"zhuangtongfa.material-theme",
 		"redhat.vscode-yaml",
-		"tamasfe.even-better-toml",
-		"seatonjiang.gitmoji-vscode",
 		"GitHub.copilot"
 	]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,7 @@
 		"ms-azuretools.vscode-docker",
 		"zhuangtongfa.material-theme",
 		"redhat.vscode-yaml",
-		"GitHub.copilot"
+		"GitHub.copilot",
+		"znck.grammarly"
 	]
 }

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 .pytest_cache
 __pycache__
 poetry.lock
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ venv.bak/
 
 # Poetry
 *poetry.lock*
+
+# DS Store
+.DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: 22.6.0
     hooks:
       - id: black
+        args: ["--preview"]
         language_version: python3
 
   - repo: https://github.com/PyCQA/isort

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 `investiny` has been created due to the latest Investing.com changes in their API protection protocols, as 
 now their main APIs are Cloudflare V2 protected. Anyway, there are still some APIs working fine, so this package
 has been created as a temporary replacement for `investpy` while we get to an agreement to continue the development
-of `investpy`. In the meantime, anyone can use `investiny` as I'm actively working on it, and ideally it should support
+of `investpy`. In the meantime, anyone can use `investiny` as I'm actively working on it, and ideally, it should support
 most of the functionality provided by `investpy`.
+
 
 ---
 
@@ -52,7 +53,7 @@ data = historical_data(investing_id=6408, from_date="09/01/2022", to_date="10/01
 ```
 
 There's also a function to look for assets in Investing.com, that also lets you retrieve
-the Investing.com ID that you can later on use in `historical_data` as input parameter.
+the Investing.com ID that you can, later on, use in `historical_data` as an input parameter.
 
 ```python
 from investiny import search_assets
@@ -60,8 +61,8 @@ from investiny import search_assets
 results = search_assets(query="AAPL", limit=1, type="Stock", exchange="NASDAQ") # Returns a list with all the results found in Investing.com
 ```
 
-As `search_assets` returns a list of results, you can check each of them, and retrieve the `ticker` from the
-asset that you want to retrieve historical data from and pass it as parameter to `historical_data`. So on, the
+As `search_assets` returns a list of results, you can check each of them, retrieve the `ticker` from the
+asset that you want to retrieve historical data from and pass it as a parameter to `historical_data`. So on, the
 combination of both functions should look like the following:
 
 ```python
@@ -73,12 +74,13 @@ investing_id = int(search_results[0]["ticker"]) # Assuming the first entry is th
 data = historical_data(investing_id=investing_id, from_date="09/01/2022", to_date="10/01/2022")
 ```
 
+
 ## ⚠️ Disclaimer
 
-Investing.com is a registered trademark from Investing.com, and their services offered by Fusion Media Limited.
+Investing.com is a registered trademark of Investing.com, and its services are offered by Fusion Media Limited.
 
-Neither `investpy` nor `investiny` are affiliated, endorsed, or vetted by Investing.com.
+Neither `investpy` nor `investiny` is affiliated, endorsed, or vetted by Investing.com.
 
-Both `investpy` and `investiny` are open source packages that use Investing.com's available data, intended for research and educational purposes only.
+Both `investpy` and `investiny` are open-source packages that use Investing.com's available data, intended for research and educational purposes only.
 
 You should refer to Investing.com's terms and conditions at https://www.investing.com/about-us/terms-and-conditions for details on your rights to use the actual data, as it is intended for personal use only.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # 🤏🏻 `investpy` but made tiny
 
-Suuuuuuuper simple and tiny `investpy` replacement while I try to fix it! Here I'll try
-to add more or less the same functionality that was developed for `investpy` while keeping this
-package tiny and up-to-date, as some solutions just work temporarily.
+**`investiny` is faster, lighter, and easier to use** than `investpy`.
 
-Everyone using `investiny` please go thank @ramakrishnamekala129 for proposing this solution
-that seems to be stable and working fine so far (fingers crossed!).
-
-Remember that `investiny` shouldn't be considered reliable, as even though it's working fine, 
-it may be discontinued, so please use it mindfully.
+`investiny` has been created due to the latest Investing.com changes in their API protection protocols, as 
+now their main APIs are Cloudflare V2 protected. Anyway, there are still some APIs working fine, so this package
+has been created as a temporary replacement for `investpy` while we get to an agreement to continue the development
+of `investpy`. In the meantime, anyone can use `investiny` as I'm actively working on it, and ideally it should support
+most of the functionality provided by `investpy`.
 
 ---
 

--- a/docs/disclaimer.md
+++ b/docs/disclaimer.md
@@ -1,9 +1,9 @@
 # ⚠️ Disclaimer
 
-Investing.com is a registered trademark from Investing.com, and their services offered by Fusion Media Limited.
+Investing.com is a registered trademark of Investing.com, and its services are offered by Fusion Media Limited.
 
-Neither `investpy` nor `investiny` are affiliated, endorsed, or vetted by Investing.com.
+Neither `investpy` nor `investiny` is affiliated, endorsed, or vetted by Investing.com.
 
-Both `investpy` and `investiny` are open source packages that use Investing.com's available data, intended for research and educational purposes only.
+Both `investpy` and `investiny` are open-source packages that use Investing.com's available data, intended for research and educational purposes only.
 
 You should refer to Investing.com's terms and conditions at https://www.investing.com/about-us/terms-and-conditions for details on your rights to use the actual data, as it is intended for personal use only.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,5 +5,5 @@
 `investiny` has been created due to the latest Investing.com changes in their API protection protocols, as 
 now their main APIs are Cloudflare V2 protected. Anyway, there are still some APIs working fine, so this package
 has been created as a temporary replacement for `investpy` while we get to an agreement to continue the development
-of `investpy`. In the meantime, anyone can use `investiny` as I'm actively working on it, and ideally it should support
+of `investpy`. In the meantime, anyone can use `investiny` as I'm actively working on it, and ideally, it should support
 most of the functionality provided by `investpy`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,9 @@
 # 🤏🏻 `investpy` but made tiny
 
-Suuuuuuuper simple and tiny `investpy` replacement while I try to fix it! Here I'll try
-to add more or less the same functionality that was developed for `investpy` while keeping this
-package tiny and up-to-date, as some solutions just work temporarily.
+**`investiny` is faster, lighter, and easier to use** than `investpy`.
 
-Everyone using `investiny` please go thank @ramakrishnamekala129 for proposing this solution
-that seems to be stable and working fine so far (fingers crossed!).
-
-Remember that `investiny` shouldn't be considered reliable, as even though it's working fine, 
-it may be discontinued, so please use it mindfully.
+`investiny` has been created due to the latest Investing.com changes in their API protection protocols, as 
+now their main APIs are Cloudflare V2 protected. Anyway, there are still some APIs working fine, so this package
+has been created as a temporary replacement for `investpy` while we get to an agreement to continue the development
+of `investpy`. In the meantime, anyone can use `investiny` as I'm actively working on it, and ideally it should support
+most of the functionality provided by `investpy`.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -27,5 +27,5 @@ data.set_index("Date", inplace=True)
 
 ## ➕ More to come...
 
-Feel free to submit a PR to update the documenation by adding more integrations with any
+Feel free to submit a PR to update the documentation by adding more integrations with any
 other package/library that you think can be useful to be documented.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,0 +1,18 @@
+# 🛂 Limitations
+After some extensive testing to explore further Investing.com's API limitations, we ran some tests to see whether Cloudflare was blocking incoming requests, and
+it's not, so the API used by `investiny` seems stable enough for the moment (🤞🏻 fingers crossed!).
+
+But besides that, there's a known limitation that we've spotted while retrieving historical data depending on the intervals used. All the limitations are now handled internally, so this is done transparently for the user, but whenever it comes to intra-day data, it seems that just a portion of it is available on Investing.com.
+
+So here's the table with the intra-day data limitations:
+
+| Interval | Limitation |
+|:--:|--:|
+| **1 min** | 6 months |
+| **5 min** | ~ 1 year |
+| **15 min** | ~ 1.5 years |
+| **30 min** | ~ 2 years |
+| **60 min (1 hour) ** | ~ 5 years |
+| **300 min (5 hours) ** | ~ 13 years |
+
+For the rest of the possible `interval` values for `investiny.historical_data` it doesn't seem to be any known limitation yet.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,7 @@ data = historical_data(investing_id=6408, from_date="09/01/2022", to_date="10/01
 ```
 
 There's also a function to look for assets in Investing.com, that also lets you retrieve
-the Investing.com ID that you can later on use in `historical_data` as input parameter.
+the Investing.com ID that you can, later on, use in `historical_data` as an input parameter.
 
 ```python
 from investiny import search_assets
@@ -18,8 +18,8 @@ from investiny import search_assets
 results = search_assets(query="AAPL", limit=1, type="Stock", exchange="NASDAQ") # Returns a list with all the results found in Investing.com
 ```
 
-As `search_assets` returns a list of results, you can check each of them, and retrieve the `ticker` from the
-asset that you want to retrieve historical data from and pass it as parameter to `historical_data`. So on, the
+As `search_assets` returns a list of results, you can check each of them, retrieve the `ticker` from the
+asset that you want to retrieve historical data from and pass it as a parameter to `historical_data`. So on, the
 combination of both functions should look like the following:
 
 ```python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
   - Requirements: requirements.md
   - Installation: installation.md
   - Usage: usage.md
+  - Limitations: limitations.md
   - Integrations: integrations.md
   - API Reference:
       - Historical: api/historical.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ license = "MIT License"
 [tool.poetry.dependencies]
 python = "^3.8"
 httpx = "^0.23.0"
+pydantic = "^1.10.2"
 mkdocs = { version = "^1.4.0", optional = true }
 mkdocs-material = { version = "^8.5.4", optional = true }
 mkdocs-git-revision-date-localized-plugin = { version = "^1.1.0", optional = true }

--- a/src/investiny/config.py
+++ b/src/investiny/config.py
@@ -1,0 +1,9 @@
+import os
+
+from pydantic.dataclasses import dataclass
+
+
+@dataclass
+class Config:
+    date_format: str = os.getenv("INVESTINY_DATE_FORMAT", "%m/%d/%Y")
+    time_format: str = os.getenv("INVESTINY_TIME_FORMAT", "%m/%d/%Y %H:%M")

--- a/src/investiny/historical.py
+++ b/src/investiny/historical.py
@@ -58,7 +58,10 @@ def historical_data(
             "resolution": interval,
         }
         data = request_to_investing(endpoint="history", params=params)
-        result["date"] += [datetime.fromtimestamp(t, tz=timezone.utc).strftime(datetime_format) for t in data["t"]]  # type: ignore
+        result["date"] += [
+            datetime.fromtimestamp(t, tz=timezone.utc).strftime(datetime_format)
+            for t in data["t"]  # type: ignore
+        ]
         result["open"] += data["o"]  # type: ignore
         result["high"] += data["h"]  # type: ignore
         result["low"] += data["l"]  # type: ignore

--- a/src/investiny/historical.py
+++ b/src/investiny/historical.py
@@ -4,6 +4,7 @@
 from datetime import datetime, timezone
 from typing import Any, Dict, Literal, Union
 
+from investiny.config import Config
 from investiny.utils import calculate_date_intervals, request_to_investing
 
 
@@ -40,7 +41,9 @@ def historical_data(
         "volume": [],
     }
 
-    time_format = "%m/%d/%Y %H:%M" if interval not in ["D", "W", "M"] else "%m/%d/%Y"
+    datetime_format = (
+        Config.time_format if interval not in ["D", "W", "M"] else Config.date_format
+    )
 
     for to_datetime, from_datetime in zip(to_datetimes, from_datetimes):
         params = {
@@ -50,7 +53,7 @@ def historical_data(
             "resolution": interval,
         }
         data = request_to_investing(endpoint="history", params=params)
-        result["date"] += [datetime.fromtimestamp(t, tz=timezone.utc).strftime(time_format) for t in data["t"]]  # type: ignore
+        result["date"] += [datetime.fromtimestamp(t, tz=timezone.utc).strftime(datetime_format) for t in data["t"]]  # type: ignore
         result["open"] += data["o"]  # type: ignore
         result["high"] += data["h"]  # type: ignore
         result["low"] += data["l"]  # type: ignore

--- a/src/investiny/historical.py
+++ b/src/investiny/historical.py
@@ -6,8 +6,6 @@ from typing import Any, Dict, Literal, Union
 
 from investiny.utils import calculate_date_intervals, request_to_investing
 
-__all__ = ["historical_data"]
-
 
 def historical_data(
     investing_id: int,

--- a/src/investiny/historical.py
+++ b/src/investiny/historical.py
@@ -1,7 +1,7 @@
 # Copyright 2022 Alvaro Bartolome, alvarobartt @ GitHub
 # See LICENSE for details.
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Literal, Union
 
 from investiny.utils import calculate_date_intervals, request_to_investing
@@ -42,6 +42,8 @@ def historical_data(
         "volume": [],
     }
 
+    time_format = "%m/%d/%Y %H:%M" if interval not in ["D", "W", "M"] else "%m/%d/%Y"
+
     for to_datetime, from_datetime in zip(to_datetimes, from_datetimes):
         params = {
             "symbol": investing_id,
@@ -50,8 +52,7 @@ def historical_data(
             "resolution": interval,
         }
         data = request_to_investing(endpoint="history", params=params)
-        time_format = "%H:%M %m/%d/%Y" if isinstance(interval, int) else "%m/%d/%Y"
-        result["date"] += [datetime.fromtimestamp(t).strftime(time_format) for t in data["t"]]  # type: ignore
+        result["date"] += [datetime.fromtimestamp(t, tz=timezone.utc).strftime(time_format) for t in data["t"]]  # type: ignore
         result["open"] += data["o"]  # type: ignore
         result["high"] += data["h"]  # type: ignore
         result["low"] += data["l"]  # type: ignore

--- a/src/investiny/historical.py
+++ b/src/investiny/historical.py
@@ -17,16 +17,16 @@ def historical_data(
     """Get historical data from Investing.com.
 
     Args:
-        investing_id (int): Investing.com's ID for the asset.
-        from_date (Union[str, None], optional): Initial date to retrieve historical data (formatted as m/d/Y). Defaults to None.
-        to_date (Union[str, None], optional): Final date to retrieve historical data (formatted as m/d/Y). Defaults to None.
-        interval (Literal[1, 5, 15, 30, 45, 60, 120, 240, 300, "D", "W", "M"], optional): Interval between each historical data point. Defaults to "D".
+        investing_id: Investing.com's ID for the asset.
+        from_date: Initial date to retrieve historical data (formatted as m/d/Y). Defaults to None.
+        to_date: Final date to retrieve historical data (formatted as m/d/Y). Defaults to None.
+        interval: Interval between each historical data point. Defaults to "D".
 
     Note:
         If no dates are introduced, the function will retrieve the last 30 days of historical data.
 
     Returns:
-        Dict[str, Any]: A dictionary with the historical data.
+        A dictionary with the historical data from Investing.com.
     """
     from_datetimes, to_datetimes = calculate_date_intervals(
         from_date=from_date, to_date=to_date, interval=interval

--- a/src/investiny/historical.py
+++ b/src/investiny/historical.py
@@ -1,10 +1,10 @@
 # Copyright 2022 Alvaro Bartolome, alvarobartt @ GitHub
 # See LICENSE for details.
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from typing import Any, Dict, Literal, Union
 
-from investiny.utils import request_to_investing
+from investiny.utils import calculate_date_intervals, request_to_investing
 
 __all__ = ["historical_data"]
 
@@ -29,31 +29,9 @@ def historical_data(
     Returns:
         Dict[str, Any]: A dictionary with the historical data.
     """
-    if from_date and to_date:
-        from_datetimes = [
-            datetime.strptime(from_date, "%m/%d/%Y").astimezone(tz=timezone.utc)
-        ]
-        to_datetimes = [
-            datetime.strptime(to_date, "%m/%d/%Y").astimezone(tz=timezone.utc)
-        ]
-        if from_datetimes[0] > to_datetimes[0]:
-            raise ValueError("`from_date` cannot be greater than `to_date`")
-        if to_datetimes[0] - from_datetimes[0] > timedelta(
-            days=6940
-        ):  # round(365.25 * 19)
-            max_to_datetime = to_datetimes[0]
-            to_datetimes = [from_datetimes[0] + timedelta(days=6940)]
-            while to_datetimes[-1] - from_datetimes[-1] > timedelta(
-                days=6940
-            ):  # round(365.25*19) = 6940
-                from_datetimes.append(to_datetimes[-1] + timedelta(days=1))
-                to_datetimes.append(from_datetimes[-1] + timedelta(days=6940))
-            if to_datetimes[-1] != max_to_datetime:
-                from_datetimes.append(to_datetimes[-1] + timedelta(days=1))
-                to_datetimes.append(max_to_datetime)
-    else:
-        to_datetimes = [datetime.now(tz=timezone.utc)]
-        from_datetimes = [to_datetimes[0] - timedelta(days=30)]
+    from_datetimes, to_datetimes = calculate_date_intervals(
+        from_date=from_date, to_date=to_date, interval=interval
+    )
 
     result: Dict[str, Any] = {
         "date": [],

--- a/src/investiny/historical.py
+++ b/src/investiny/historical.py
@@ -19,7 +19,9 @@ def historical_data(
     Args:
         investing_id: Investing.com's ID for the asset.
         from_date: Initial date to retrieve historical data (formatted as m/d/Y). Defaults to None.
-        to_date: Final date to retrieve historical data (formatted as m/d/Y). Defaults to None.
+        to_date:
+            Final date to retrieve historical data (formatted as m/d/Y). Defaults to None,
+            unless `from_date` is specified, that defaults to current date.
         interval: Interval between each historical data point. Defaults to "D".
 
     Note:
@@ -28,6 +30,9 @@ def historical_data(
     Returns:
         A dictionary with the historical data from Investing.com.
     """
+    if from_date and not to_date:
+        to_date = datetime.now(tz=timezone.utc).strftime(Config.date_format)
+
     from_datetimes, to_datetimes = calculate_date_intervals(
         from_date=from_date, to_date=to_date, interval=interval
     )

--- a/src/investiny/historical.py
+++ b/src/investiny/historical.py
@@ -12,7 +12,7 @@ def historical_data(
     investing_id: int,
     from_date: Union[str, None] = None,
     to_date: Union[str, None] = None,
-    interval: Literal[1, 5, 15, 30, 45, 60, 120, 240, 300, "D", "W", "M"] = "D",
+    interval: Literal[1, 5, 15, 30, 60, 300, "D", "W", "M"] = "D",
 ) -> Dict[str, Any]:
     """Get historical data from Investing.com.
 

--- a/src/investiny/historical.py
+++ b/src/investiny/historical.py
@@ -1,7 +1,7 @@
 # Copyright 2022 Alvaro Bartolome, alvarobartt @ GitHub
 # See LICENSE for details.
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Literal, Union
 
 from investiny.utils import request_to_investing
@@ -30,10 +30,12 @@ def historical_data(
         Dict[str, Any]: A dictionary with the historical data.
     """
     if from_date and to_date:
-        from_datetime = datetime.strptime(from_date, "%m/%d/%Y")
-        to_datetime = datetime.strptime(to_date, "%m/%d/%Y")
+        from_datetime = datetime.strptime(from_date, "%m/%d/%Y").astimezone(
+            tz=timezone.utc
+        )
+        to_datetime = datetime.strptime(to_date, "%m/%d/%Y").astimezone(tz=timezone.utc)
     else:
-        to_datetime = datetime.now()
+        to_datetime = datetime.now(tz=timezone.utc)
         from_datetime = to_datetime - timedelta(days=30)
 
     params = {

--- a/src/investiny/search.py
+++ b/src/investiny/search.py
@@ -28,13 +28,13 @@ def search_assets(
     """Search any available asset at Investing.com.
 
     Args:
-        query (str): Query to search for.
-        limit (int, optional): Maximum number of results to retrieve. Defaults to 10.
-        type (Union[Literal["Stock", "ETF", "Commodity", "Index", "Future", "Yield", "FX"], None], optional): Type of asset to search for. Defaults to None.
-        exchange (Union[str, None], optional): Exchange to search for. Defaults to None.
+        query: Query to search for.
+        limit: Maximum number of results to retrieve. Defaults to 10.
+        type: Type of asset to search for. Defaults to None.
+        exchange: Exchange to search for. Defaults to None.
 
     Returns:
-        List[Dict[str, Any]]: A list of dictionaries with the search results.
+        A list of dictionaries with the search results from Investing.com.
     """
     params = {
         "query": query,

--- a/src/investiny/utils.py
+++ b/src/investiny/utils.py
@@ -39,7 +39,18 @@ def request_to_investing(
         raise ConnectionError(
             f"Request to Investing.com API failed with error code: {r.status_code}."
         )
-    return r.json()  # type: ignore
+    d = r.json()
+    if d["s"] != "ok":
+        raise ConnectionError(
+            f"Request to Investing.com API failed with error message: {d['s']}."
+            if "nextTime" not in d
+            else (
+                f"Request to Investing.com API failed with error message: {d['s']}, the"
+                " market was probably closed in the introduced dates, try again with"
+                f" `from_date={datetime.fromtimestamp(d['nextTime'], tz=timezone.utc).strftime(Config.date_format)}`."
+            )
+        )
+    return d  # type: ignore
 
 
 def calculate_date_intervals(

--- a/src/investiny/utils.py
+++ b/src/investiny/utils.py
@@ -40,7 +40,8 @@ def request_to_investing(
             f"Request to Investing.com API failed with error code: {r.status_code}."
         )
     d = r.json()
-    if d["s"] != "ok":
+
+    if endpoint == "history" and d["s"] != "ok":
         raise ConnectionError(
             f"Request to Investing.com API failed with error message: {d['s']}."
             if "nextTime" not in d

--- a/src/investiny/utils.py
+++ b/src/investiny/utils.py
@@ -57,7 +57,7 @@ def request_to_investing(
 def calculate_date_intervals(
     from_date: Union[str, None] = None,
     to_date: Union[str, None] = None,
-    interval: Literal[1, 5, 15, 30, 45, 60, 120, 240, 300, "D", "W", "M"] = "D",
+    interval: Literal[1, 5, 15, 30, 60, 300, "D", "W", "M"] = "D",
 ) -> Tuple[List[datetime], List[datetime]]:
     """Calculates the intervals between the introduced dates.
 
@@ -74,10 +74,7 @@ def calculate_date_intervals(
         5: timedelta(hours=1),  # 1 hour
         15: timedelta(hours=3),  # 3 hours
         30: timedelta(hours=6),  # 6 hours
-        45: timedelta(hours=12),  # 12 hours (half a day)
         60: timedelta(hours=24),  # 24 hours (one day)
-        120: timedelta(hours=48),  # 48 hours (two days)
-        240: timedelta(hours=96),  # 96 hours (four days)
         300: timedelta(hours=120),  # 120 hours (five days)
         "D": timedelta(days=30),  # 30 days (~ 1 month)
         "W": timedelta(days=90),  # 3 months
@@ -114,18 +111,20 @@ def calculate_date_intervals(
     ]:  # There are no data retrieval limits for weekly and monthly intervals
         return (from_datetimes, to_datetimes)
 
-    if interval not in [1, 5, 15, 30, "D"]:
+    if interval not in [1, 5, 15, 30, 60, "D"]:
         logging.warning(
-            "Interval calculation just implemented for 1, 5, 15, 30, 'D' intervals,"
+            "Interval calculation just implemented for 1, 5, 15, 30, 60, 'D' intervals,"
             f" not for {interval}, wait for its implementation."
         )
         return (from_datetimes, to_datetimes)
 
     interval2limit = {
-        1: timedelta(days=13),  # round(5000 / 390) = 13 days (round to half a month)
-        5: timedelta(days=64),  # round(5000 / 78) = 64 days (round to two months)
-        15: timedelta(days=192),  # round(5000 / 26) = 192 days (round to six months)
-        30: timedelta(days=384),  # round(5000 / 13) = 384 days (round to one year)
+        1: timedelta(days=17),
+        5: timedelta(days=91),
+        15: timedelta(days=275),
+        30: timedelta(days=554),
+        60: timedelta(days=1030),
+        300: timedelta(days=3282),
         "D": timedelta(
             days=6940
         ),  # round(365.25 * 19) = 6940 days (5000 days + bank holidays, weekends, etc.)
@@ -136,15 +135,19 @@ def calculate_date_intervals(
         5: timedelta(minutes=5),
         15: timedelta(minutes=15),
         30: timedelta(minutes=30),
+        60: timedelta(hours=1),
+        300: timedelta(hours=5),
         "D": timedelta(days=1),
     }
 
     if interval != "D":
         no_more_than = {
-            1: timedelta(days=182.5),
-            5: timedelta(days=258.5),
-            15: timedelta(days=457.5),
-            30: timedelta(days=661.5),
+            1: timedelta(days=186),
+            5: timedelta(days=259),
+            15: timedelta(days=458),
+            30: timedelta(days=662),
+            60: timedelta(days=1927),
+            300: timedelta(days=4833),
         }
 
         if (

--- a/src/investiny/utils.py
+++ b/src/investiny/utils.py
@@ -98,7 +98,7 @@ def calculate_date_intervals(
         to_datetimes = [
             datetime.strptime(to_date, Config.time_format).astimezone(tz=timezone.utc)
         ]
-    else:
+    except Exception:
         raise ValueError(
             f"Only supported date formats are `{Config.date_format}` and"
             f" `{Config.time_format}`."

--- a/src/investiny/utils.py
+++ b/src/investiny/utils.py
@@ -19,11 +19,11 @@ def request_to_investing(
     """Sends an HTTP GET request to Investing.com API with the introduced params.
 
     Args:
-        endpoint (Literal["history", "search"]): Endpoint to send the request to.
-        params (Dict[str, Any]): A dictionary with the params to send to Investing.com API.
+        endpoint: Endpoint to send the request to.
+        params: A dictionary with the params to send to Investing.com API.
 
     Returns:
-        Dict[str, Any]: A dictionary with the response from Investing.com API.
+        A dictionary with the response from Investing.com API.
     """
     url = f"https://tvc4.investing.com/{uuid4().hex}/0/0/0/0/{endpoint}"
     headers = {
@@ -62,12 +62,12 @@ def calculate_date_intervals(
     """Calculates the intervals between the introduced dates.
 
     Args:
-        from_date (Union[str, None], optional): Initial date to retrieve historical data (formatted as m/d/Y). Defaults to None.
-        to_date (Union[str, None], optional): Final date to retrieve historical data (formatted as m/d/Y). Defaults to None.
-        interval (Literal[1, 5, 15, 30, 45, 60, 120, 240, 300, "D", "W", "M"]): Interval between each historical data point. Defaults to "D".
+        from_date: Initial date to retrieve historical data (formatted as m/d/Y). Defaults to None.
+        to_date: Final date to retrieve historical data (formatted as m/d/Y). Defaults to None.
+        interval: Interval between each historical data point. Defaults to "D".
 
     Returns:
-        Tuple[List[str], List[str]]: A tuple with the from and to datetimes split by intervals.
+        A tuple with the from and to datetimes split by intervals.
     """
     interval2timedelta = {
         1: timedelta(minutes=30),  # 30 minutes (half an hour)

--- a/src/investiny/utils.py
+++ b/src/investiny/utils.py
@@ -129,7 +129,7 @@ def calculate_date_intervals(
     if to_datetimes[0] - from_datetimes[0] > interval2limit[interval]:  # type: ignore
         max_to_datetime = to_datetimes[0]
         to_datetimes = [from_datetimes[0] + interval2limit[interval]]  # type: ignore
-        while to_datetimes[-1] - from_datetimes[-1] > interval2limit[interval]:  # type: ignore
+        while max_to_datetime - to_datetimes[-1] > interval2limit[interval]:  # type: ignore
             from_datetimes.append(to_datetimes[-1] + interval2increment[interval])  # type: ignore
             to_datetimes.append(from_datetimes[-1] + interval2limit[interval])  # type: ignore
         if to_datetimes[-1] != max_to_datetime:

--- a/src/investiny/utils.py
+++ b/src/investiny/utils.py
@@ -8,6 +8,8 @@ from uuid import uuid4
 
 import httpx
 
+from investiny.config import Config
+
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 
 
@@ -76,20 +78,19 @@ def calculate_date_intervals(
         return (from_datetimes, to_datetimes)
 
     try:
-        date_format = "%m/%d/%Y"
-        from_datetimes = [datetime.strptime(from_date, date_format)]
-        to_datetimes = [datetime.strptime(to_date, date_format)]
+        from_datetimes = [datetime.strptime(from_date, Config.date_format)]
+        to_datetimes = [datetime.strptime(to_date, Config.date_format)]
     except ValueError:
-        date_format = "%m/%d/%Y %H:%M"
         from_datetimes = [
-            datetime.strptime(from_date, date_format).astimezone(tz=timezone.utc)
+            datetime.strptime(from_date, Config.time_format).astimezone(tz=timezone.utc)
         ]
         to_datetimes = [
-            datetime.strptime(to_date, date_format).astimezone(tz=timezone.utc)
+            datetime.strptime(to_date, Config.time_format).astimezone(tz=timezone.utc)
         ]
     else:
         raise ValueError(
-            "Only supported date formats are `%m/%d/%Y` and `%m/%d/%Y %H:%M`."
+            f"Only supported date formats are `{Config.date_format}` and"
+            f" `{Config.time_format}`."
         )
 
     if from_datetimes[0] > to_datetimes[0]:

--- a/src/investiny/utils.py
+++ b/src/investiny/utils.py
@@ -10,8 +10,6 @@ import httpx
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 
-__all__ = ["calculate_date_intervals", "request_to_investing"]
-
 
 def request_to_investing(
     endpoint: Literal["history", "search"], params: Dict[str, Any]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,20 @@ def to_date() -> str:
 
 
 @pytest.fixture
+def from_date_wide_range() -> str:
+    """Initial date to retrieve historical data (formatted as m/d/Y) but with a wider range.
+    """
+    return "01/01/2000"
+
+
+@pytest.fixture
+def to_date_wide_range() -> str:
+    """Final date to retrieve historical data (formatted as m/d/Y) but with a wider range.
+    """
+    return "01/01/2022"
+
+
+@pytest.fixture
 def query() -> str:
     """Query to search assets in Investing.com."""
     return "GOOGL"

--- a/tests/test_historical.py
+++ b/tests/test_historical.py
@@ -24,3 +24,18 @@ def test_historical_without_dates(investing_id: int) -> None:
         key in res.keys() for key in ["date", "open", "high", "low", "close", "volume"]
     )
     assert isinstance(res, dict)
+
+
+@pytest.mark.usefixtures("investing_id", "from_date_wide_range", "to_date_wide_range")
+def test_historical_wide_range(
+    investing_id: int, from_date_wide_range: str, to_date_wide_range: str
+) -> None:
+    res = historical_data(
+        investing_id=investing_id,
+        from_date=from_date_wide_range,
+        to_date=to_date_wide_range,
+    )
+    assert all(
+        key in res.keys() for key in ["date", "open", "high", "low", "close", "volume"]
+    )
+    assert isinstance(res, dict)


### PR DESCRIPTION
## ✨ Features

- Add conversion for all dates with times to UTC to avoid timezone issues
- Set `to_date` param's default value to the current date
- Improve `request_to_investing` error handling
- Add interval handling for: "D", "W", "M", 1 min, 5 mins, 15 mins, 30 mins, 60 mins and 300 mins

## 🐛 Bug Fixes

- Handle data limits per each request to Investing.com (when `interval="D"` the maximum amount of data to retrieve is 19 years of data, just like in `investpy`)
- Fix conversion of `%m/%d/%Y` dates to UTC, as for the `UTC+` timezones, it was reducing the date by the hours skew, which was resulting in wrong historical data retrieval results
- Fix interval calculation in `calculate_date_intervals` as `while` loop was calculating `to_datetime` minus `from_datetime` difference, when what had to be calculated for the loop to continue for more than one iteration was `max_to_datetime` minus `to_datetime`

## 🔮 TODOs

- [X] Handle data limits for all available intervals
  - [X]  Daily -> Limit is around 19 years
  - [X] Weekly -> No data limits
  - [X] Monthly -> No data limits
  - [X] Minutes (1, 5, 15, 30, ~45~, 60, ~120~, ~240~, 300)
- [X] Is https://tvc4.investing.com also limited when retrieving intraday data? -> Yes, same limit as `interval="D"` on 5000 results
- [X] In order to provide useful intraday data, we should also provide the input format `%H:%M %m/%d/%Y` for both `from_date` and `to_date` -> At the end we decided to use `%m/%d/%Y %H:%M` instead
- [X] Add/Explain limitations in documentation

## 📌 Additional Information

It seems that both https://tvc4.investing.com and https://tvc6.investing.com APIs have a limitation of 5000 results, which for `interval="D"` seems something easy to calculate, while for intra-day intervals is a little bit harder as the amount of minutes/hours in a trading day depends on the exchange, but we'll be calculating an estimation over NASDAQ or NYSE assets, as those are the most active ones, so as to overestimate the intervals and make sure we don't lose data.

## 🔗 Linked Issue/s

#24 #28 #31 

## 🧪 Tests

- [X] Did you implement unit tests if required?

If the above checkbox is checked, describe how you unit-tested it.

In order to test `historical_data` with wider date ranges, we've included a new unit test named `test_historical_wide_range` and two new values for both `from_date` and `to_date` named `from_date_wide_range` and `to_date_wide_range`, so as to make sure that we can retrieve daily (`interval="D"`) data of more than 19 years.