### PR TITLE
🐛 Fix `to_date` handling when specified

### DIFF
--- a/src/investiny/utils.py
+++ b/src/investiny/utils.py
@@ -89,7 +89,7 @@ def calculate_date_intervals(
     try:
         from_datetimes = [datetime.strptime(from_date, Config.date_format)]
         to_datetimes = [
-            datetime.strptime(to_date, Config.date_format)
+            datetime.strptime(to_date, Config.date_format) + timedelta(days=1)
             if to_date
             else datetime.now()
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,27 +13,27 @@ def investing_id() -> int:
 @pytest.fixture
 def from_date() -> str:
     """Initial date to retrieve historical data (formatted as m/d/Y)."""
-    return "01/01/2021"
+    return "01/04/2021"
 
 
 @pytest.fixture
 def to_date() -> str:
     """Final date to retrieve historical data (formatted as m/d/Y)."""
-    return "01/01/2022"
+    return "12/31/2021"
 
 
 @pytest.fixture
 def from_date_wide_range() -> str:
     """Initial date to retrieve historical data (formatted as m/d/Y) but with a wider range.
     """
-    return "01/01/2000"
+    return "01/03/2000"
 
 
 @pytest.fixture
 def to_date_wide_range() -> str:
     """Final date to retrieve historical data (formatted as m/d/Y) but with a wider range.
     """
-    return "01/01/2022"
+    return "12/31/2021"
 
 
 @pytest.fixture

--- a/tests/test_historical.py
+++ b/tests/test_historical.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from investiny import historical_data  # noqa: F401
+from investiny import historical_data
 
 
 @pytest.mark.usefixtures("investing_id", "from_date", "to_date")
@@ -11,19 +11,21 @@ def test_historical(investing_id: int, from_date: str, to_date: str) -> None:
     res = historical_data(
         investing_id=investing_id, from_date=from_date, to_date=to_date
     )
+    assert isinstance(res, dict)
     assert all(
         key in res.keys() for key in ["date", "open", "high", "low", "close", "volume"]
     )
-    assert isinstance(res, dict)
+    assert res["date"][0] == from_date
+    assert res["date"][-1] == to_date
 
 
 @pytest.mark.usefixtures("investing_id")
 def test_historical_without_dates(investing_id: int) -> None:
     res = historical_data(investing_id=investing_id)
+    assert isinstance(res, dict)
     assert all(
         key in res.keys() for key in ["date", "open", "high", "low", "close", "volume"]
     )
-    assert isinstance(res, dict)
 
 
 @pytest.mark.usefixtures("investing_id", "from_date_wide_range", "to_date_wide_range")
@@ -35,7 +37,9 @@ def test_historical_wide_range(
         from_date=from_date_wide_range,
         to_date=to_date_wide_range,
     )
+    assert isinstance(res, dict)
     assert all(
         key in res.keys() for key in ["date", "open", "high", "low", "close", "volume"]
     )
-    assert isinstance(res, dict)
+    assert res["date"][0] == from_date_wide_range
+    assert res["date"][-1] == to_date_wide_range


### PR DESCRIPTION
## 🐛 Bug Fixes

- Fix `to_date` param handling when `to_date` is specified and matches current date

## 🔗 Linked Issue

https://github.com/alvarobartt/investiny/issues/28

## 🧪 Tests

- [X] Did you implement unit tests if required?

If the above checkbox is checked, describe how you unit-tested it.

All the `from_date` and `to_date` fixtures defined have been updated so as to exactly match the first and the last entries of the retrieved data using `historical_data`, respectively.