### PR TITLE
✨ Add `info`, `investing_info`, and solve timezone issue

### DIFF
--- a/docs/api/info.md
+++ b/docs/api/info.md
@@ -1,0 +1,1 @@
+::: investiny.info.info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ license = "MIT License"
 python = "^3.8"
 httpx = "^0.23.0"
 pydantic = "^1.10.2"
+pytz = "^2022.4"
 mkdocs = { version = "^1.4.0", optional = true }
 mkdocs-material = { version = "^8.5.4", optional = true }
 mkdocs-git-revision-date-localized-plugin = { version = "^1.1.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ isort = "^5.10.1"
 mypy = "^0.971"
 pre-commit = "^2.20.0"
 pytest = "^7.1.2"
+types-pytz = "^2022.4.0.0"
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "investiny"
-version = "0.6.0"
+version = "0.7.0"
 packages = [
     { include = "investiny", from = "src" },
 ]

--- a/src/investiny/__init__.py
+++ b/src/investiny/__init__.py
@@ -7,4 +7,5 @@ __author__ = "Alvaro Bartolome, alvarobartt @ GitHub"
 __version__ = "0.7.0"
 
 from investiny.historical import historical_data  # noqa: F401
+from investiny.info import info  # noqa: F401
 from investiny.search import search_assets  # noqa: F401

--- a/src/investiny/__init__.py
+++ b/src/investiny/__init__.py
@@ -4,7 +4,7 @@
 """`investiny `: `investpy` but made tiny."""
 
 __author__ = "Alvaro Bartolome, alvarobartt @ GitHub"
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 from investiny.historical import historical_data  # noqa: F401
 from investiny.search import search_assets  # noqa: F401

--- a/src/investiny/historical.py
+++ b/src/investiny/historical.py
@@ -1,10 +1,13 @@
 # Copyright 2022 Alvaro Bartolome, alvarobartt @ GitHub
 # See LICENSE for details.
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Dict, Literal, Union
 
+import pytz
+
 from investiny.config import Config
+from investiny.info import investing_info
 from investiny.utils import calculate_date_intervals, request_to_investing
 
 
@@ -47,6 +50,9 @@ def historical_data(
         Config.time_format if interval not in ["D", "W", "M"] else Config.date_format
     )
 
+    info = investing_info(investing_id=investing_id)
+    tz = pytz.timezone(info["timezone"])
+
     for to_datetime, from_datetime in zip(to_datetimes, from_datetimes):
         params = {
             "symbol": investing_id,
@@ -56,7 +62,7 @@ def historical_data(
         }
         data = request_to_investing(endpoint="history", params=params)
         result["date"] += [
-            datetime.fromtimestamp(t, tz=timezone.utc).strftime(datetime_format)
+            datetime.fromtimestamp(t, tz=tz).strftime(datetime_format)
             for t in data["t"]  # type: ignore
         ]
         result["open"] += data["o"]  # type: ignore

--- a/src/investiny/info.py
+++ b/src/investiny/info.py
@@ -23,10 +23,11 @@ def info(asset: Union[str, List[str]]) -> Dict[str, Any]:
         endpoint="quotes",
         params={"symbols": asset if isinstance(asset, str) else ",".join(asset)},
     )
-    if len(results["d"]) < 2:
-        return {results["d"][0]["n"]: results["d"][0]["v"]}
+    actual_results = results["d"]  # type: ignore
+    if len(actual_results) < 2:
+        return {actual_results[0]["n"]: actual_results[0]["v"]}
     r = {}
-    for result in results["d"]:
+    for result in actual_results:
         r[result["n"]] = result["v"]
     return r
 
@@ -40,7 +41,7 @@ def investing_info(investing_id: int) -> Dict[str, Any]:
     Returns:
         A dictionary with the asset's information used internally by Investing.com.
     """
-    return request_to_investing(
+    return request_to_investing(  # type: ignore
         endpoint="symbols",
         params={"symbol": investing_id},
     )

--- a/src/investiny/info.py
+++ b/src/investiny/info.py
@@ -1,0 +1,19 @@
+# Copyright 2022 Alvaro Bartolome, alvarobartt @ GitHub
+# See LICENSE for details.
+
+from typing import Any, Dict, List, Union
+
+from investiny.utils import request_to_investing
+
+
+def obtain_info(asset: Union[str, List[str]]) -> Dict[str, Any]:
+    results = request_to_investing(
+        endpoint="quotes",
+        params={"symbols": asset if isinstance(asset, str) else ",".join(asset)},
+    )
+    if len(results["d"]) < 2:
+        return {results["d"][0]["n"]: results["d"][0]["v"]}
+    info = {}
+    for result in results["d"]:
+        info[result["n"]] = result["v"]
+    return info

--- a/src/investiny/info.py
+++ b/src/investiny/info.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Union
 from investiny.utils import request_to_investing
 
 
-def obtain_info(asset: Union[str, List[str]]) -> Dict[str, Any]:
+def info(asset: Union[str, List[str]]) -> Dict[str, Any]:
     results = request_to_investing(
         endpoint="quotes",
         params={"symbols": asset if isinstance(asset, str) else ",".join(asset)},

--- a/src/investiny/info.py
+++ b/src/investiny/info.py
@@ -17,3 +17,18 @@ def obtain_info(asset: Union[str, List[str]]) -> Dict[str, Any]:
     for result in results["d"]:
         info[result["n"]] = result["v"]
     return info
+
+
+def investing_info(investing_id: int) -> Dict[str, Any]:
+    """Get asset's information used internally by Investing.com.
+
+    Args:
+        investing_id: Investing.com's ID for the asset.
+
+    Returns:
+        A dictionary with the asset's information used internally by Investing.com.
+    """
+    return request_to_investing(
+        endpoint="symbols",
+        params={"symbol": investing_id},
+    )

--- a/src/investiny/info.py
+++ b/src/investiny/info.py
@@ -7,16 +7,28 @@ from investiny.utils import request_to_investing
 
 
 def info(asset: Union[str, List[str]]) -> Dict[str, Any]:
+    """Get assets' public information available at Investing.com
+
+    Args:
+        asset:
+            name to retrieve its information from Investing.com. Note that this arg can be:
+            the name of a single asset, a comma-separated string with asset names, or a list
+            of asset names.
+
+    Returns:
+        A dictionary with the assets' public information available at Investing.com, where the
+        key is the asset name and the value is a dictionary with the asset's information.
+    """
     results = request_to_investing(
         endpoint="quotes",
         params={"symbols": asset if isinstance(asset, str) else ",".join(asset)},
     )
     if len(results["d"]) < 2:
         return {results["d"][0]["n"]: results["d"][0]["v"]}
-    info = {}
+    r = {}
     for result in results["d"]:
-        info[result["n"]] = result["v"]
-    return info
+        r[result["n"]] = result["v"]
+    return r
 
 
 def investing_info(investing_id: int) -> Dict[str, Any]:

--- a/src/investiny/utils.py
+++ b/src/investiny/utils.py
@@ -14,7 +14,7 @@ logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 
 
 def request_to_investing(
-    endpoint: Literal["history", "search"], params: Dict[str, Any]
+    endpoint: Literal["history", "search", "quotes"], params: Dict[str, Any]
 ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
     """Sends an HTTP GET request to Investing.com API with the introduced params.
 
@@ -41,7 +41,7 @@ def request_to_investing(
         )
     d = r.json()
 
-    if endpoint == "history" and d["s"] != "ok":
+    if endpoint in ["history", "quotes"] and d["s"] != "ok":
         raise ConnectionError(
             f"Request to Investing.com API failed with error message: {d['s']}."
             if "nextTime" not in d

--- a/src/investiny/utils.py
+++ b/src/investiny/utils.py
@@ -14,7 +14,7 @@ logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 
 
 def request_to_investing(
-    endpoint: Literal["history", "search", "quotes"], params: Dict[str, Any]
+    endpoint: Literal["history", "search", "quotes", "symbols"], params: Dict[str, Any]
 ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
     """Sends an HTTP GET request to Investing.com API with the introduced params.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 # Copyright 2022 Alvaro Bartolome, alvarobartt @ GitHub
 # See LICENSE for details.
 
+from typing import List
+
 import pytest
 
 
@@ -40,3 +42,21 @@ def to_date_wide_range() -> str:
 def query() -> str:
     """Query to search assets in Investing.com."""
     return "GOOGL"
+
+
+@pytest.fixture
+def asset() -> str:
+    """Asset to retrieve its information from Investing.com."""
+    return "NASDAQ:AAPL"
+
+
+@pytest.fixture
+def assets() -> str:
+    """Comma-separated assets to retrieve their information from Investing.com."""
+    return "NASDAQ:AAPL,NASDAQ:GOOGL"
+
+
+@pytest.fixture
+def asset_list() -> List[str]:
+    """List of assets to retrieve their information from Investing.com."""
+    return ["NASDAQ:AAPL", "NASDAQ:GOOGL"]

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,0 +1,29 @@
+# Copyright 2022 Alvaro Bartolome, alvarobartt @ GitHub
+# See LICENSE for details.
+
+from typing import List
+
+import pytest
+
+from investiny import info
+
+
+@pytest.mark.usefixtures("asset")
+def test_info_with_asset(asset: str) -> None:
+    res = info(asset=asset)
+    assert isinstance(res, dict)
+    assert asset in res.keys()
+
+
+@pytest.mark.usefixtures("assets")
+def test_info_with_assets(assets: str) -> None:
+    res = info(asset=assets)
+    assert isinstance(res, dict)
+    assert all(key in res.keys() for key in assets.split(","))
+
+
+@pytest.mark.usefixtures("asset_list")
+def test_info_with_asset_list(asset_list: List[str]) -> None:
+    res = info(asset=asset_list)
+    assert isinstance(res, dict)
+    assert all(key in res.keys() for key in asset_list)


### PR DESCRIPTION
## ✨ Features

- Add both `/quotes` and `/symbols` https://tvc4.investing.com endpoints under `info` and `investing_info`, respectively.
- Add `pytz` dependency to handle timezones, as it's more complete than `datetime.timezone`
- Update documentation accordingly

## 🐛 Bug Fixes

- Fix bug on `historical_data`'s output dates, as with `investing_info` we can retrieve the operating timezone of each asset and use `pytz` to properly convert the timestamps

## 🔗 Linked Issue

#40 

## 🧪 Tests

- [X] Did you implement unit tests if required?

If the above checkbox is checked, describe how you unit-tested it.

`investiny.info` has been unit tested with the different input types available, and `investiny.investing_info` has not been tested yet, as it's just used internally and everything is already handled.