### PR TITLE
🐛 Fix recurrent bug with non-matching dates

### DIFF
--- a/src/investiny/utils.py
+++ b/src/investiny/utils.py
@@ -82,7 +82,7 @@ def calculate_date_intervals(
     }
 
     if not from_date:
-        to_datetimes = [datetime.now(tz=timezone.utc)]
+        to_datetimes = [datetime.now() + timedelta(days=1)]
         from_datetimes = [to_datetimes[0] - interval2timedelta[interval]]
         return (from_datetimes, to_datetimes)
 
@@ -91,7 +91,7 @@ def calculate_date_intervals(
         to_datetimes = [
             datetime.strptime(to_date, Config.date_format) + timedelta(days=1)
             if to_date
-            else datetime.now()
+            else datetime.now() + timedelta(days=1)
         ]
         limit_datetime = datetime(1970, 1, 1)
     except ValueError:


### PR DESCRIPTION
## 🐛 Bug Fixes

- Add `timedelta(days=1)` to `datetime.now()` objects when interval is either daily, weekly, or monthly.
- Include a day-shift calculation, as, for some assets, their timestamps don't match the actual dates, e.g. U.S. 10Y.

## 🔗 Linked Issue

#40 

## 🧪 Tests

- [X] Did you implement unit tests if required?

If the above checkbox is checked, describe how you unit-tested it.

Current unit tests were not passing due to the timezone conversions, but after implementing the day-shift mechanism, those are working back again, since the timezones didn't have anything to do with the bug.