### PR TITLE
✨ Add `has_volume` check to avoid `n/a` volume values

### DIFF
--- a/src/investiny/historical.py
+++ b/src/investiny/historical.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, Literal, Union
 
 from investiny.config import Config
+from investiny.info import investing_info
 from investiny.utils import calculate_date_intervals, request_to_investing
 
 
@@ -44,6 +45,8 @@ def historical_data(
         Config.time_format if interval not in ["D", "W", "M"] else Config.date_format
     )
 
+    has_volume = not investing_info(investing_id=investing_id)["has_no_volume"]
+
     for to_datetime, from_datetime in zip(to_datetimes, from_datetimes):
         params = {
             "symbol": investing_id,
@@ -64,7 +67,7 @@ def historical_data(
         result["high"] += data["h"]  # type: ignore
         result["low"] += data["l"]  # type: ignore
         result["close"] += data["c"]  # type: ignore
-        if "v" in data:
+        if has_volume:
             result["volume"] += data["v"]  # type: ignore
     if len(result["volume"]) < 1:
         result.pop("volume")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,3 +57,8 @@ def assets() -> str:
 def asset_list() -> List[str]:
     """List of assets to retrieve their information from Investing.com."""
     return ["NASDAQ:AAPL", "NASDAQ:GOOGL"]
+
+
+@pytest.fixture
+def investing_id_no_volume() -> int:
+    return 1

--- a/tests/test_historical.py
+++ b/tests/test_historical.py
@@ -40,3 +40,10 @@ def test_historical_wide_range(
     )
     assert res["date"][0] == from_date_wide_range
     assert res["date"][-1] == to_date_wide_range
+
+
+@pytest.mark.usefixtures("investing_id_no_volume")
+def test_historical_no_volume(investing_id_no_volume: int) -> None:
+    res = historical_data(investing_id=investing_id_no_volume)
+    assert isinstance(res, dict)
+    assert "volume" not in res.keys()


### PR DESCRIPTION
## ✨ Features

- Add `has_volume` flag that checks `has_no_volume` in `investing_info` results so as not to include the `volume` in the results (as the key will always be there)

## 🔗 Linked Issue

#41 

## 🧪 Tests

- [X] Did you implement unit tests if required?

If the above checkbox is checked, describe how you unit-tested it.

I've included a unit test for `EUR/USD` with `investing_id=1`, as it doesn't have `volume`, so there's an assertion for that to avoid returning the `volume` key in `historical_data`'s results when it's not available (n/a).