### PR TITLE
🐛 Fix issue with wrong timestamps for Bond Yields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "investiny"
-version = "0.7.0"
+version = "0.7.1"
 packages = [
     { include = "investiny", from = "src" },
 ]

--- a/src/investiny/__init__.py
+++ b/src/investiny/__init__.py
@@ -1,7 +1,7 @@
 """`investiny `: `investpy` but made tiny."""
 
 __author__ = "Alvaro Bartolome, alvarobartt @ GitHub"
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 from investiny.historical import historical_data  # noqa: F401
 from investiny.info import info  # noqa: F401

--- a/src/investiny/historical.py
+++ b/src/investiny/historical.py
@@ -45,7 +45,10 @@ def historical_data(
         Config.time_format if interval not in ["D", "W", "M"] else Config.date_format
     )
 
-    has_volume = not investing_info(investing_id=investing_id)["has_no_volume"]
+    info = investing_info(investing_id=investing_id)
+
+    has_volume = not info["has_no_volume"]
+    days_shift = 1 if info["type"] in ["Yield"] else 0
 
     for to_datetime, from_datetime in zip(to_datetimes, from_datetimes):
         params = {
@@ -55,8 +58,6 @@ def historical_data(
             "resolution": interval,
         }
         data = request_to_investing(endpoint="history", params=params)
-        # Dates are shifted due to an Investing.com issue with returned timestamps
-        days_shift = (datetime.fromtimestamp(data["t"][0]) - from_datetime).days  # type: ignore
         result["date"] += [
             (datetime.fromtimestamp(t) - timedelta(days=days_shift)).strftime(
                 datetime_format


### PR DESCRIPTION
## 🐛 Bug Fixes

- Fix issue with `historical_data` timestamps for `Bond Yield` as timestamps were shifted by one day

## 🔗 Linked Issue

#28 