### PR TITLE
🚑️ Fix URL to point `tvc6.investing.com` as `tvc4` is blocked

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ available at Investing.com goes from 1 minute to monthly data.
 
 `investpy` uses Investing.com's APIs at https://www.investing.com/instruments/HistoricalDataAjax and at
 https://api.investing.com/api/financialdata/historical, that are Cloudflare protected and not working any more,
-as you'll end up getting blocked with 403 Forbidden HTTP code; while `investiny` is using https://tvc4.investing.com/,
+as you'll end up getting blocked with 403 Forbidden HTTP code; while `investiny` is using https://tvc6.investing.com/,
 which seems to be more reliable right now according to the ran tests, as well as providing intraday data.
 
 | | Intraday Data | Any Range Historical Data | Search Assets/Quotes | Dividends | Economic Calendar | Technical Indicators | Economic News |

--- a/docs/differences-with-investpy.md
+++ b/docs/differences-with-investpy.md
@@ -10,7 +10,7 @@ available at Investing.com goes from 1 minute to monthly data.
 
 `investpy` uses Investing.com's APIs at https://www.investing.com/instruments/HistoricalDataAjax and at
 https://api.investing.com/api/financialdata/historical, that are Cloudflare protected and not working any more,
-as you'll end up getting blocked with 403 Forbidden HTTP code; while `investiny` is using https://tvc4.investing.com/,
+as you'll end up getting blocked with 403 Forbidden HTTP code; while `investiny` is using https://tvc6.investing.com/,
 which seems to be more reliable right now according to the ran tests, as well as providing intraday data.
 
 | | Intraday Data | Any Range Historical Data | Search Assets/Quotes | Dividends | Economic Calendar | Technical Indicators | Economic News |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "investiny"
-version = "0.7.1"
+version = "0.7.2"
 packages = [
     { include = "investiny", from = "src" },
 ]

--- a/src/investiny/__init__.py
+++ b/src/investiny/__init__.py
@@ -1,7 +1,7 @@
 """`investiny `: `investpy` but made tiny."""
 
 __author__ = "Alvaro Bartolome, alvarobartt @ GitHub"
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 from investiny.historical import historical_data  # noqa: F401
 from investiny.info import info  # noqa: F401

--- a/src/investiny/utils.py
+++ b/src/investiny/utils.py
@@ -22,7 +22,7 @@ def request_to_investing(
     Returns:
         A dictionary with the response from Investing.com API.
     """
-    url = f"https://tvc4.investing.com/{uuid4().hex}/0/0/0/0/{endpoint}"
+    url = f"https://tvc6.investing.com/{uuid4().hex}/0/0/0/0/{endpoint}"
     headers = {
         "User-Agent": (
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like"


### PR DESCRIPTION
## 🐛 Bug Fixes

- Change Investing.com URL from `tvc4.investing.com` to `tvc6.investing.com`, as `tvc4.investing.com` which was the Investing.com URL used by default was blocking all the incoming requests with HTTP 403, but `tvc6.investing.com` seems stable now.

## 🔗 Linked Issue

Reported at https://github.com/alvarobartt/investiny/issues/53 solved at https://github.com/alvarobartt/investiny/issues/54